### PR TITLE
Add origin based rate limit

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,5 +6,6 @@ services:
       - 80:8080
     environment:
       - RATE_LIMIT=60
+      - ORIGIN_RATE_LIMIT=600
       # - CLIENT_IP_HEADER=X-Real-IP
     restart: always


### PR DESCRIPTION
- Restrict to cross-origin request only (having Origin header)
- Origin based rate limit via `ORIGIN_RATE_LIMIT` separate to the default IP based rate limit
- Add validation for local origins to use IP based
- Adjust compose yaml example

The origin based rate limit will take precedence over the IP based rate limit when configured.
